### PR TITLE
feat: add mailhog to test email

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,3 +17,8 @@ services:
     extends:
       file: common-services.yml
       service: mariadb
+
+  mailhog:
+    image: blueimp/mailhog
+    ports:
+      - 127.0.0.1:${MAILHOG_PORT:-8025}:8025


### PR DESCRIPTION
Mailhog is a SMTP service that intercept the email sending at application, store this in memory, repply to who sent the email and don't delivery the email to the real receiver. Then, we can access all sent email into an URL and test if the application is working fine to send emails without spamming the real inboxes.