### PR TITLE
Replace MailHog with Mailpit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,10 +13,10 @@ TZ=America/Sao_Paulo
 # Xdebug Configuration
 XDEBUG_CONFIG="remote_host=172.17.0.1 remote_enable=1"
 
-WORDPRESS_CONFIG_EXTRA="define('WP_MAILHOG_HOST', 'mailhog');
+WORDPRESS_CONFIG_EXTRA="define('WP_MAILPIT_HOST', 'mailpit');
 define( 'SMTP_USER',   'user@example.com' );    // Username to use for SMTP authentication
 define( 'SMTP_PASS',   'smtp password' );       // Password to use for SMTP authentication
-define( 'SMTP_HOST',   'mailhog' );    // The hostname of the mail server
+define( 'SMTP_HOST',   'mailpit' );    // The hostname of the mail server
 define( 'SMTP_FROM',   'website@example.com' ); // SMTP From email address
 define( 'SMTP_NAME',   'e.g Website Name' );    // SMTP From name
 define( 'SMTP_PORT',   '1025' );                  // SMTP port number - likely to be 25, 465 or 587

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,7 +18,7 @@ services:
       file: common-services.yml
       service: mariadb
 
-  mailhog:
-    image: blueimp/mailhog
+  mailpit:
+    image: axllent/mailpit
     ports:
-      - 127.0.0.1:${MAILHOG_PORT:-8025}:8025
+      - 127.0.0.1:${MAILPIT_PORT:-8025}:8025


### PR DESCRIPTION
## Summary
- Replace the dev mail service from MailHog to Mailpit
- Update the exposed port variable to `MAILPIT_PORT`
- Adjust the sample environment configuration to point to `mailpit`

## Notes
- No runtime behavior changes beyond the SMTP/dev mail service swap