### PR TITLE
Update WordPress default to 6.9

### DIFF
--- a/common-services.yml
+++ b/common-services.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .docker/wordpress
       args:
-        VERSION_WORDPRESS: ${VERSION_WORDPRESS:-6.7}
+        VERSION_WORDPRESS: ${VERSION_WORDPRESS:-6.9}
         VERSION_PHP: ${VERSION_PHP:-8.3}
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
## Summary
- Update the shared WordPress image default to 6.9

## Notes
- The Dockerfile already consumes `VERSION_WORDPRESS`, so this change updates the default used by the compose setup