### PR TITLE
Hotfix: fix GHCR image name casing in publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,7 +59,7 @@ jobs:
             VERSION_WORDPRESS=${{ env.VERSION_WORDPRESS }}
             VERSION_PHP=${{ env.VERSION_PHP }}
           tags: |
-            ghcr.io/${{ github.repository_owner }}/wordpress-docker:${{ github.sha }}
+            ghcr.io/librecodecoop/wordpress-docker:${{ github.sha }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 
@@ -75,8 +75,8 @@ jobs:
             VERSION_WORDPRESS=${{ env.VERSION_WORDPRESS }}
             VERSION_PHP=${{ env.VERSION_PHP }}
           tags: |
-            ghcr.io/${{ github.repository_owner }}/wordpress-docker:${{ github.sha }}
-            ghcr.io/${{ github.repository_owner }}/wordpress-docker:latest
+            ghcr.io/librecodecoop/wordpress-docker:${{ github.sha }}
+            ghcr.io/librecodecoop/wordpress-docker:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 


### PR DESCRIPTION
## Problem
The Docker publish workflow builds image tags using `${{ github.repository_owner }}`. In this repository, that resolves to `LibreCodeCoop`, and GHCR image names must be lowercase.

## Fix
- Replace dynamic owner-based tags with explicit lowercase namespace:
  - `ghcr.io/librecodecoop/wordpress-docker:${{ github.sha }}`
  - `ghcr.io/librecodecoop/wordpress-docker:latest`

## Expected result
The `Docker WordPress Publish` job should stop failing on invalid image/tag naming and push successfully to GHCR.