### PR TITLE
Remove broken doc links and unused config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,10 @@ Create a local file named `docker-compose.override.yml` in the project root with
 ```yaml
 services:
   wordpress:
-    extends:
-      file: common-services.yml
-      service: wordpress
     environment:
       - XDEBUG_MODE=${XDEBUG_MODE:-debug}
 
   nginx:
-    extends:
-      file: common-services.yml
-      service: nginx
     ports:
       - 80:80
 
@@ -64,9 +58,6 @@ docker compose exec --user www-data wordpress wp language core update
 docker compose exec --user www-data wordpress wp language plugin update --all
 docker compose exec --user www-data wordpress wp theme update --all
 ```
-
-* [Ambiente de desenvolvimento](docs/ambiente-dev-local.md)
-* [Atualização de versão de WordPress e plugins](docs/atualizacao.md)
 
 ## Checking if have files changed at core
 

--- a/common-services.yml
+++ b/common-services.yml
@@ -34,8 +34,6 @@ services:
       - LETSENCRYPT_HOST
 
   mariadb:
-    profiles:
-      - dev
     build:
       context: .docker/mariadb
     volumes:


### PR DESCRIPTION
## Summary
- Remove broken links to non-existing docs (`docs/ambiente-dev-local.md` and `docs/atualizacao.md`) from README
- Remove unused build config from `common-services.yml`