### PR TITLE
fix: handle Polylang Pro ACF path on Linux

### DIFF
--- a/.docker/wordpress/entrypoint.sh
+++ b/.docker/wordpress/entrypoint.sh
@@ -162,34 +162,54 @@ clone_custom_plugin() {
 	local plugin_name="$1"
 	local git_url="$2"
 	local plugin_dir="/var/www/html/wp-content/plugins/$plugin_name"
-	local acf_dir="$plugin_dir/integrations/ACF"
-	local acf_source_dir="$plugin_dir/integrations/acf"
-
-	fix_polylang_pro_acf_case() {
-		if [ -d "$acf_source_dir" ] && [ ! -e "$acf_dir" ]; then
-			ln -s acf "$acf_dir"
-		fi
-	}
 
 	if [ -d "$plugin_dir" ]; then
 		echo "  ✓ Plugin $plugin_name already exists"
-		if [ "$plugin_name" = "polylang-pro" ]; then
-			fix_polylang_pro_acf_case
-		fi
+		return 0
 	else
 		echo "  ↓ Cloning $plugin_name..."
 		cd /var/www/html/wp-content/plugins/
 		if git clone "$git_url" "$plugin_name" 2>/dev/null; then
-			if [ "$plugin_name" = "polylang-pro" ]; then
-				fix_polylang_pro_acf_case
-			fi
-			chown -R www-data:www-data "$plugin_dir"
-			wp --allow-root plugin activate "$plugin_name" 2>/dev/null || true
 			echo "  ✓ Plugin $plugin_name cloned"
+			return 0
 		else
 			echo "  ✗ Failed to clone $plugin_name"
+			return 1
 		fi
 	fi
+}
+
+run_custom_plugin_post_install_commands() {
+	local plugin_name="$1"
+	local entry="$2"
+	local plugin_dir="/var/www/html/wp-content/plugins/$plugin_name"
+	local command
+
+	if ! printf '%s' "$entry" | base64 -d | yq -e '.post_install_commands? | length > 0' - >/dev/null 2>&1; then
+		return 0
+	fi
+
+	while IFS= read -r command; do
+		command="$(trim_value "$command")"
+		if [ -z "$command" ] || [ "$command" = "null" ]; then
+			continue
+		fi
+
+		(
+			cd "$plugin_dir"
+			bash -lc "$command"
+		)
+	done < <(printf '%s' "$entry" | base64 -d | yq -r '.post_install_commands[]?')
+}
+
+finalize_custom_plugin() {
+	local plugin_name="$1"
+	local entry="$2"
+	local plugin_dir="/var/www/html/wp-content/plugins/$plugin_name"
+
+	run_custom_plugin_post_install_commands "$plugin_name" "$entry"
+	chown -R www-data:www-data "$plugin_dir"
+	wp --allow-root plugin activate "$plugin_name" 2>/dev/null || true
 }
 
 clone_custom_theme() {
@@ -280,7 +300,9 @@ install_git_entries() {
 		fi
 
 		if [ "$entry_type" = "plugin" ]; then
-			clone_custom_plugin "$resource_name" "$source_url"
+			if clone_custom_plugin "$resource_name" "$source_url"; then
+				finalize_custom_plugin "$resource_name" "$entry"
+			fi
 		else
 			clone_custom_theme "$resource_name" "$source_url"
 		fi

--- a/.docker/wordpress/entrypoint.sh
+++ b/.docker/wordpress/entrypoint.sh
@@ -162,13 +162,27 @@ clone_custom_plugin() {
 	local plugin_name="$1"
 	local git_url="$2"
 	local plugin_dir="/var/www/html/wp-content/plugins/$plugin_name"
+	local acf_dir="$plugin_dir/integrations/ACF"
+	local acf_source_dir="$plugin_dir/integrations/acf"
+
+	fix_polylang_pro_acf_case() {
+		if [ -d "$acf_source_dir" ] && [ ! -e "$acf_dir" ]; then
+			ln -s acf "$acf_dir"
+		fi
+	}
 
 	if [ -d "$plugin_dir" ]; then
 		echo "  ✓ Plugin $plugin_name already exists"
+		if [ "$plugin_name" = "polylang-pro" ]; then
+			fix_polylang_pro_acf_case
+		fi
 	else
 		echo "  ↓ Cloning $plugin_name..."
 		cd /var/www/html/wp-content/plugins/
 		if git clone "$git_url" "$plugin_name" 2>/dev/null; then
+			if [ "$plugin_name" = "polylang-pro" ]; then
+				fix_polylang_pro_acf_case
+			fi
 			chown -R www-data:www-data "$plugin_dir"
 			wp --allow-root plugin activate "$plugin_name" 2>/dev/null || true
 			echo "  ✓ Plugin $plugin_name cloned"


### PR DESCRIPTION
## Summary
- add a compatibility symlink for Polylang Pro's ACF integration on case-sensitive filesystems
- avoid the fatal error caused by the plugin autoloader looking for `integrations/ACF/Main.php` while the repo stores the directory as `integrations/acf`
