### PR TITLE
fix: generic post_install_commands hook for custom plugins

### DIFF
--- a/.docker/wordpress/entrypoint.sh
+++ b/.docker/wordpress/entrypoint.sh
@@ -196,7 +196,8 @@ run_custom_plugin_post_install_commands() {
 		fi
 
 		(
-			cd "$plugin_dir"
+			cd /var/www/html
+			export PLUGIN_DIR="$plugin_dir"
 			bash -lc "$command"
 		)
 	done < <(printf '%s' "$entry" | base64 -d | yq -r '.post_install_commands[]?')


### PR DESCRIPTION
- Adds `run_custom_plugin_post_install_commands()` to entrypoint, running each command from WP root with `PLUGIN_DIR` env var exposed
- Fixes Polylang Pro ACF case-sensitivity on Linux via symlink post-install command
- Adds `wp-simple-smtp` SMTP config pointing to mailpit (host=mailpit, port=1025)