### PR TITLE
fix: embed PLUGIN_DIR in bash -lc command to survive login shell env reset

### DIFF
--- a/.docker/wordpress/entrypoint.sh
+++ b/.docker/wordpress/entrypoint.sh
@@ -197,8 +197,7 @@ run_custom_plugin_post_install_commands() {
 
 		(
 			cd /var/www/html
-			export PLUGIN_DIR="$plugin_dir"
-			bash -lc "$command"
+			bash -lc "export PLUGIN_DIR='$plugin_dir'; $command"
 		)
 	done < <(printf '%s' "$entry" | base64 -d | yq -r '.post_install_commands[]?')
 }


### PR DESCRIPTION
When `post_install_commands` run via `bash -lc`, the login shell sources `/etc/profile` and `/etc/profile.d/*` scripts which can discard variables exported by the parent process.

**Symptom:** `$PLUGIN_DIR` expanded to empty, causing the Polylang Pro symlink command to target `/integrations/ACF` instead of the full plugin path:
```
ln: failed to create symbolic link '/integrations/ACF': No such file or directory
```

**Fix:** embed the variable directly in the string passed to `bash -lc` so it is set inside the login shell before the command runs:
```bash
bash -lc "export PLUGIN_DIR='$plugin_dir'; $command"
```