### PR TITLE
docs: escape PLUGIN_DIR in compose YAML example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ services:
           - slug: my-plugin-with-fixup
             source: https://github.com/org/my-plugin-with-fixup.git
             post_install_commands:
-              - ln -sfn real-dir "$PLUGIN_DIR/expected-dir"
+              - ln -sfn real-dir "$$PLUGIN_DIR/expected-dir"
               - wp --allow-root option update my_plugin_option value
 
         # Themes cloned from a Git repository.


### PR DESCRIPTION
Fixes the README example for post_install_commands in docker-compose override.

- Replaces `` with `207035PLUGIN_DIR` in YAML example
- Prevents Docker Compose from expanding the variable on the host side
- Keeps expansion for runtime inside the container shell