### PR TITLE
docs: refine README intro and add database dump guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,16 @@
 # Wordpress
 
-## About this project
+This repository provides a Docker setup to run a WordPress stack with plugins and themes.
 
-This repository provides a reproducible Docker environment for running a WordPress stack used by LibreSign and related integrations.
-
-The main goal is to make local development, onboarding, and environment recovery fast and predictable, without manual server setup.
+The main goal is to make local development, onboarding, and environment recovery quick, without manual server setup.
 
 It is useful when you need to:
-- Run WordPress with MariaDB and Nginx in a consistent way across machines.
+- Run WordPress with MariaDB and Nginx the same way on any machine.
 - Import production-like data and remap URLs for local usage.
 - Install plugins and themes automatically, including custom Git repositories.
 - Configure local integrations (for example SMTP with mailpit, or other plugin-specific settings) during startup.
 
-In short, this project reduces setup friction and keeps local behavior close to real deployment scenarios.
-
-[It will be necessary to have the docker installed in its operating system to execute this project.](https://docs.docker.com/get-docker/)
+Prerequisite: [Docker](https://docs.docker.com/get-docker/) must be installed on your operating system.
 
 
 ## Setup
@@ -95,6 +91,24 @@ After that, start the stack with the standard Compose command:
 docker compose up -d --build
 docker compose exec --user www-data wordpress wp user reset-password <username> --show-password --skip-email
 ```
+
+### Database dump
+
+If you need to bootstrap the environment with existing data, place your SQL dump in the folder below:
+
+`volumes/mariadb/dump/`
+
+How it works:
+- Files in this folder are mounted at `/docker-entrypoint-initdb.d` inside MariaDB.
+- They are imported automatically only when the MariaDB data directory is empty (first initialization).
+
+If your database is already initialized and you want to import a dump manually:
+
+```bash
+docker compose exec -T mariadb sh -lc 'mariadb -uroot -p"$MARIADB_ROOT_PASSWORD" "$MARIADB_DATABASE"' < volumes/mariadb/dump/your-dump.sql
+```
+
+If you want to force automatic re-import from `/docker-entrypoint-initdb.d`, remove the existing database files in `volumes/mariadb/data` and start the stack again.
 
 ### Local e-mail (mailpit)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # Wordpress
 
+## About this project
+
+This repository provides a reproducible Docker environment for running a WordPress stack used by LibreSign and related integrations.
+
+The main goal is to make local development, onboarding, and environment recovery fast and predictable, without manual server setup.
+
+It is useful when you need to:
+- Run WordPress with MariaDB and Nginx in a consistent way across machines.
+- Import production-like data and remap URLs for local usage.
+- Install plugins and themes automatically, including custom Git repositories.
+- Configure local integrations (for example SMTP with mailpit, or other plugin-specific settings) during startup.
+
+In short, this project reduces setup friction and keeps local behavior close to real deployment scenarios.
+
 [It will be necessary to have the docker installed in its operating system to execute this project.](https://docs.docker.com/get-docker/)
 
 


### PR DESCRIPTION
This PR improves the README onboarding flow before the setup tutorial.

Changes:
- Add a concise project introduction at the top
- Make wording environment-agnostic and more natural
- Replace the awkward full-sentence prerequisite link with a cleaner Docker prerequisite sentence
- Add a dedicated Database dump section with automatic import behavior and manual import command