### PR TITLE
fix(wordpress): set plugin ownership before post-install commands

### DIFF
--- a/.docker/wordpress/entrypoint.sh
+++ b/.docker/wordpress/entrypoint.sh
@@ -204,8 +204,8 @@ finalize_custom_plugin() {
 	local entry="$2"
 	local plugin_dir="/var/www/html/wp-content/plugins/$plugin_name"
 
-	run_custom_plugin_post_install_commands "$plugin_name" "$entry"
 	chown -R www-data:www-data "$plugin_dir"
+	run_custom_plugin_post_install_commands "$plugin_name" "$entry"
 	runuser -u www-data -- wp plugin activate "$plugin_name" 2>/dev/null || true
 }
 


### PR DESCRIPTION
## Summary
This fix prevents startup crashes when a custom plugin post-install command needs write access to the plugin directory (for example, creating `integrations/ACF` symlink in `polylang-pro`).

## Root cause
`finalize_custom_plugin()` was running `post_install_commands` as `www-data` **before** adjusting ownership of the cloned plugin directory. Since cloning is done as root, some commands failed with `Permission denied` and broke the bootstrap flow.

## Change
- In `.docker/wordpress/entrypoint.sh`, run `chown -R www-data:www-data "$plugin_dir"` **before** `run_custom_plugin_post_install_commands`.

## Validation
- Rebuilt WordPress image and restarted service.
- Confirmed container remained running.
- Checked logs for regressions (`Permission denied`, `Fatal error`, `Class not found`) and found none after the fix.