### PR TITLE
[codex] admin password default

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ services:
       # Set one shared password and choose one strategy:
       # - reset all local users, or
       # - reset only one specific user login/email/ID.
-      WORDPRESS_LOCAL_USERS_PASSWORD: ${WORDPRESS_LOCAL_USERS_PASSWORD:-localdev123}
+      WORDPRESS_LOCAL_USERS_PASSWORD: ${WORDPRESS_LOCAL_USERS_PASSWORD:-admin}
       WORDPRESS_LOCAL_RESET_ALL_USERS_PASSWORDS: ${WORDPRESS_LOCAL_RESET_ALL_USERS_PASSWORDS:-1}
       WORDPRESS_LOCAL_RESET_PASSWORD_FOR_USER: ${WORDPRESS_LOCAL_RESET_PASSWORD_FOR_USER:-}
       # Inline YAML config for automatic plugin/theme installation.


### PR DESCRIPTION
## What changed
- Updated the local WordPress default user password from `localdev123` to `admin` in the submodule README.

## Why
- The local SaaS workflow is being standardized around the existing `admlibrecode` account with password `admin` for faster onboarding and testing.

## Impact
- The submodule documentation now matches the local root compose defaults and the reset flow used in this workspace.

## Validation
- Checked the compose configuration from the repository root.
- Reset the local `admlibrecode` account password while testing the flow.